### PR TITLE
CJavascriptObject::CheckAttr bug fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,11 @@ import logging
 
 from distutils.command.build import build
 from distutils.command.install import install
-from setuptools import setup, Extension
+
+try:
+    from setuptools import setup, Extension
+except ImportError:
+    from distutils.core import setup, Extension
 
 from settings import *
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import logging
 
 from distutils.command.build import build
 from distutils.command.install import install
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 from settings import *
 

--- a/src/Wrapper.cpp
+++ b/src/Wrapper.cpp
@@ -964,7 +964,7 @@ void CJavascriptObject::CheckAttr(v8::Handle<v8::String> name) const
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
-  if (!Object()->Has(context, name).ToChecked())
+  if (!Object()->Has(context, name).FromMaybe(false))
   {
     std::ostringstream msg;
 
@@ -990,9 +990,6 @@ py::object CJavascriptObject::GetAttr(const std::string& name)
   v8::Handle<v8::String> attr_name = DecodeUtf8(name);
 
   CheckAttr(attr_name);
-
-  if (!Object()->Has(context, attr_name).FromMaybe(false))
-    CJavascriptException::ThrowIf(isolate, try_catch);
 
   v8::Handle<v8::Value> attr_value = Object()->Get(context, attr_name).ToLocalChecked();
 

--- a/src/Wrapper.cpp
+++ b/src/Wrapper.cpp
@@ -991,6 +991,9 @@ py::object CJavascriptObject::GetAttr(const std::string& name)
 
   CheckAttr(attr_name);
 
+  if (!Object()->Has(context, attr_name).FromMaybe(false))
+    CJavascriptException::ThrowIf(isolate, try_catch);
+
   v8::Handle<v8::Value> attr_value = Object()->Get(context, attr_name).ToLocalChecked();
 
   if (attr_value.IsEmpty())


### PR DESCRIPTION
This patch fixes a bug in CJavascriptObject::GetAttr where a not existent attribute could lead to a STPyV8 crash