### PR TITLE
ICU support

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -16,6 +16,8 @@ STPYV8_VERSION = V8_GIT_TAG_STABLE
 
 v8_deps_linux = os.environ.get('V8_DEPS_LINUX', '1') in ('1', )
 
+ICU_DAT_FOLDER = '/usr/share/stpyv8'
+
 os.environ['PATH'] = "{}:{}".format(os.environ['PATH'], DEPOT_HOME)
 
 gn_args = {

--- a/settings.py
+++ b/settings.py
@@ -16,7 +16,10 @@ STPYV8_VERSION = V8_GIT_TAG_STABLE
 
 v8_deps_linux = os.environ.get('V8_DEPS_LINUX', '1') in ('1', )
 
-ICU_DAT_FOLDER = '/usr/share/stpyv8'
+if os.name in ("posix", ):
+    icu_data_folder = '/usr/share/stpyv8'
+else:
+    icu_data_folder = None
 
 os.environ['PATH'] = "{}:{}".format(os.environ['PATH'], DEPOT_HOME)
 

--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,8 @@ class stpyv8_build_no_v8(build):
 class stpyv8_install(install):
     def run(self):
         self.skip_build = True
+        os.makedirs(ICU_DAT_FOLDER, exist_ok = True)
+        shutil.copy(os.path.join(V8_HOME, "out.gn/x64.release.sample/icudtl.dat"), ICU_DAT_FOLDER)
         install.run(self)
 
 

--- a/setup.py
+++ b/setup.py
@@ -155,8 +155,12 @@ class stpyv8_build_no_v8(build):
 class stpyv8_install(install):
     def run(self):
         self.skip_build = True
-        os.makedirs(ICU_DAT_FOLDER, exist_ok = True)
-        shutil.copy(os.path.join(V8_HOME, "out.gn/x64.release.sample/icudtl.dat"), ICU_DAT_FOLDER)
+
+        if icu_data_folder:
+            os.makedirs(icu_data_folder, exist_ok = True)
+            shutil.copy(os.path.join(V8_HOME, "out.gn/x64.release.sample/icudtl.dat"),
+                        icu_data_folder)
+
         install.run(self)
 
 

--- a/src/Config.h
+++ b/src/Config.h
@@ -5,3 +5,12 @@
 
 // Enable the object lifecycle tracing support
 #define SUPPORT_TRACE_LIFECYCLE 1
+
+// ICU data file
+#define ICU_DATA_UNIX "/usr/share/stpyv8/icudtl.dat"
+
+#if defined(__linux) || defined(__APPLE)
+#  define ICU_DATA ICU_DATA_UNIX;
+#else
+#  define ICU_DATA nullptr;
+#endif

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -9,7 +9,7 @@ void CPlatform::Init()
 {
   if(inited) return;
 
-  v8::V8::InitializeICUDefaultLocation(argv.c_str());
+  v8::V8::InitializeICUDefaultLocation(argv.c_str(), GetICUDataFile());
   v8::V8::InitializeExternalStartupData(argv.c_str());
   
   platform = v8::platform::NewDefaultPlatform();

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -1,15 +1,29 @@
 #pragma once
 
+#include <fstream>
 #include <v8.h>
+
+#include "Config.h"
+
 
 class CPlatform
 {
 private:
   static bool inited;
   static std::unique_ptr<v8::Platform> platform;
+  constexpr static const char *icu_data = ICU_DATA;
+
+  const char *GetICUDataFile()
+  {
+    if (icu_data == nullptr) return nullptr;
+
+    std::ifstream ifile(icu_data);
+    if (ifile) return icu_data;
+
+    return nullptr;
+  }
 
   std::string argv;
-
 public:
   CPlatform() : argv(std::string()) {};
   CPlatform(std::string argv0) : argv(argv0) {};


### PR DESCRIPTION
This patch properly initializes ICU. Right now the ICU data file path is defined just for Linux and OSX platforms but the code is ready to be extended to other platforms if needed. Moreover a run-time check is performed to avoid referencing a non existent data file. Just in case.